### PR TITLE
[unfs3] Added missing dependencies

### DIFF
--- a/net-fs/unfs3/unfs3-0.9.22.ebuild
+++ b/net-fs/unfs3/unfs3-0.9.22.ebuild
@@ -13,7 +13,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND="!net-fs/nfs-utils"
+DEPEND="!net-fs/nfs-utils
+        sys-devel/flex"
 RDEPEND="${DEPEND}"
 
 src_install() {


### PR DESCRIPTION
I tried to build unfs3 on a vanilla crossdev environment and had to emerge sys-devel/flex first. Adding as dep.